### PR TITLE
feat(pridepy): add pridepy download module

### DIFF
--- a/modules/bigbio/pridepy/environment.yml
+++ b/modules/bigbio/pridepy/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::pridepy=0.0.14

--- a/modules/bigbio/pridepy/main.nf
+++ b/modules/bigbio/pridepy/main.nf
@@ -22,7 +22,10 @@ process PRIDEPY_DOWNLOAD {
     def args = task.ext.args ?: ''
     """
     mkdir -p output
-    pridepy ${args}
+    (
+        cd output
+        pridepy ${args}
+    )
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -33,7 +36,7 @@ process PRIDEPY_DOWNLOAD {
     stub:
     """
     mkdir -p output
-    touch output/${meta.id}.placeholder
+    touch "output/${meta.id}.placeholder"
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/bigbio/pridepy/main.nf
+++ b/modules/bigbio/pridepy/main.nf
@@ -26,7 +26,7 @@ process PRIDEPY_DOWNLOAD {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        pridepy: \$(pip show pridepy 2>/dev/null | grep Version | cut -d' ' -f2)
+        pridepy: \$(python -c "from importlib.metadata import version; print(version('pridepy'))" || echo "unknown")
     END_VERSIONS
     """
 

--- a/modules/bigbio/pridepy/main.nf
+++ b/modules/bigbio/pridepy/main.nf
@@ -1,0 +1,43 @@
+process PRIDEPY_DOWNLOAD {
+    tag "${meta.id}"
+    label 'process_low'
+    label 'process_long'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/pridepy:0.0.14--pyhdfd78af_0'
+        : 'biocontainers/pridepy:0.0.14--pyhdfd78af_0'}"
+
+    input:
+    val(meta)
+
+    output:
+    path "output/",      emit: download_dir, optional: true
+    path "versions.yml", emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    """
+    mkdir -p output
+    pridepy ${args}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        pridepy: \$(pip show pridepy 2>/dev/null | grep Version | cut -d' ' -f2)
+    END_VERSIONS
+    """
+
+    stub:
+    """
+    mkdir -p output
+    touch output/${meta.id}.placeholder
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        pridepy: 0.0.14
+    END_VERSIONS
+    """
+}

--- a/modules/bigbio/pridepy/main.nf
+++ b/modules/bigbio/pridepy/main.nf
@@ -12,8 +12,8 @@ process PRIDEPY_DOWNLOAD {
     val(meta)
 
     output:
-    path "output/",      emit: download_dir, optional: true
-    path "versions.yml", emit: versions
+    tuple val(meta), path("output/"), emit: download_dir
+    path "versions.yml",              emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/bigbio/pridepy/meta.yml
+++ b/modules/bigbio/pridepy/meta.yml
@@ -1,0 +1,46 @@
+name: pridepy
+description: Python client for PRIDE Archive — download and query proteomics datasets
+keywords:
+  - pride
+  - download
+  - proteomics
+  - raw files
+  - globus
+  - aspera
+tools:
+  - pridepy:
+      description: |
+        pridepy is a Python client for the PRIDE Archive REST API.
+        It supports downloading public/private files via FTP, Aspera, Globus (HTTPS), or S3,
+        as well as querying project metadata and file listings.
+        The specific sub-command and arguments are passed via task.ext.args.
+      homepage: https://github.com/PRIDE-Archive/pridepy
+      documentation: https://github.com/PRIDE-Archive/pridepy
+      tool_dev_url: https://github.com/PRIDE-Archive/pridepy
+      doi: ""
+      licence:
+        - "Apache-2.0"
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing task information.
+          e.g. `[ id: 'PXD001819' ]`
+output:
+  download_dir:
+    - "output/":
+        type: directory
+        description: Directory containing downloaded files (for download sub-commands)
+        pattern: "output/"
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750
+authors:
+  - "@ypriverol"
+maintainers:
+  - "@ypriverol"

--- a/modules/bigbio/pridepy/meta.yml
+++ b/modules/bigbio/pridepy/meta.yml
@@ -17,22 +17,25 @@ tools:
       homepage: https://github.com/PRIDE-Archive/pridepy
       documentation: https://github.com/PRIDE-Archive/pridepy
       tool_dev_url: https://github.com/PRIDE-Archive/pridepy
-      doi: ""
       licence:
         - "Apache-2.0"
       identifier: ""
 input:
-  - - meta:
-        type: map
-        description: |
-          Groovy Map containing task information.
-          e.g. `[ id: 'PXD001819' ]`
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing task information.
+        e.g. `[ id: 'PXD001819' ]`
 output:
   download_dir:
-    - "output/":
-        type: directory
-        description: Directory containing downloaded files (for download sub-commands)
-        pattern: "output/"
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing task information forwarded from input.
+      - "output/":
+          type: directory
+          description: Directory containing downloaded files (for download sub-commands)
+          pattern: "output/"
   versions:
     - versions.yml:
         type: file

--- a/modules/bigbio/pridepy/tests/main.nf.test
+++ b/modules/bigbio/pridepy/tests/main.nf.test
@@ -1,0 +1,28 @@
+nextflow_process {
+
+    name "Test Process PRIDEPY_DOWNLOAD"
+    script "../main.nf"
+    process "PRIDEPY_DOWNLOAD"
+    tag "modules"
+    tag "modules_bigbio"
+    tag "modules_pridepy"
+    tag "pridepy"
+
+    test("Should run stub mode") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [ id: 'PXD001819' ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert snapshot(process.out.versions).match("versions_stub")
+        }
+    }
+}

--- a/modules/bigbio/pridepy/tests/main.nf.test.snap
+++ b/modules/bigbio/pridepy/tests/main.nf.test.snap
@@ -1,0 +1,14 @@
+{
+    "versions_stub": {
+        "content": [
+            [
+                "versions.yml:md5,c27ccb04c91f92f188b7f4cf2d54ed49"
+            ]
+        ],
+        "timestamp": "2026-04-28T14:06:27.317530521",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}

--- a/modules/bigbio/pridepy/tests/nextflow.config
+++ b/modules/bigbio/pridepy/tests/nextflow.config
@@ -1,0 +1,3 @@
+process {
+    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+}


### PR DESCRIPTION
## Pull Request

### Description

Adds the pridepy module wrapping [pridepy 0.0.14](https://github.com/PRIDE-Archive/pridepy), a Python client for the PRIDE Archive REST API. The CLI is exposed via task.ext.args so callers can pick the sub-command (download-all-public-raw-files, download-file-by-name, etc.) and the protocol (aspera, globus, ftp, s3). Container: biocontainers/pridepy:0.0.14--pyhdfd78af_0.

### Checklist

- [x] Module follows nf-core standards
- [x] [main.nf](cci:7://file:///D:/Git-repository/Bigbio/quantms/modules/local/pridepy/main.nf:0:0-0:0) includes process definition
- [x] [meta.yml](cci:7://file:///D:/Git-repository/Bigbio/nf-modules/modules/bigbio/onsite/meta.yml:0:0-0:0) includes complete documentation
- [x] [environment.yml](cci:7://file:///D:/Git-repository/Bigbio/nf-modules-inspect/modules/bigbio/onsite/environment.yml:0:0-0:0) specifies dependencies
- [x] Tests are included
- [x] Code is formatted (prettier)
- [x] CI checks pass

### Module Type

- [x] New module
- [ ] Module update
- [ ] Bug fix
- [ ] Documentation

### Related Issues

N/A