### PR TITLE
fix(qpx): update container tag to 1.0.2--pyhdfd78af_1

### DIFF
--- a/modules/bigbio/qpx/main.nf
+++ b/modules/bigbio/qpx/main.nf
@@ -5,8 +5,8 @@ process QPX_EXPORT {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/qpx:1.0.2--pyhdfd78af_0'
-        : 'biocontainers/qpx:1.0.2--pyhdfd78af_0'}"
+        ? 'https://depot.galaxyproject.org/singularity/qpx:1.0.2--pyhdfd78af_1'
+        : 'biocontainers/qpx:1.0.2--pyhdfd78af_1'}"
 
     input:
     path(diann_report)


### PR DESCRIPTION
This pull request updates the container image versions used in the `QPX_EXPORT` process of the `modules/bigbio/qpx/main.nf` file. The container tags are bumped from `1.0.2--pyhdfd78af_0` to `1.0.2--pyhdfd78af_1` for both Singularity and Docker images, ensuring the workflow uses the latest build of the QPX tool.

Container image update:

* Updated the Singularity and Docker container image tags for QPX from `1.0.2--pyhdfd78af_0` to `1.0.2--pyhdfd78af_1` in `modules/bigbio/qpx/main.nf` to use the latest build.