### PR TITLE
fix(qpx): emit dataset as qpx_output/* files instead of a directory

### DIFF
--- a/modules/bigbio/qpx/main.nf
+++ b/modules/bigbio/qpx/main.nf
@@ -16,7 +16,7 @@ process QPX_EXPORT {
     val(project_accession)
 
     output:
-    path "qpx_output/" , emit: qpx_dataset
+    path "qpx_output/*", emit: qpx_dataset
     path "*.h5mu"      , emit: mudata
     path "versions.yml", emit: versions
 

--- a/modules/bigbio/qpx/meta.yml
+++ b/modules/bigbio/qpx/meta.yml
@@ -41,10 +41,10 @@ input:
       description: PRIDE project accession (e.g. PXD026600) used as output prefix
 output:
   qpx_dataset:
-    - "qpx_output/":
-        type: directory
-        description: QPX Parquet dataset directory
-        pattern: "qpx_output/"
+    - "qpx_output/*":
+        type: file
+        description: QPX Parquet dataset files
+        pattern: "qpx_output/*"
   mudata:
     - "*.h5mu":
         type: file


### PR DESCRIPTION
## What

Change the `qpx_dataset` output of the `bigbio/qpx` module from the `qpx_output/` **directory** to the **files** it contains (`qpx_output/*`).

## Why

Emitting a directory forces downstream pipelines to publish the QPX Parquet dataset under an intermediate `qpx_output/` subfolder. With a Nextflow `publishDir`, a directory output and a sibling file output (the `.h5mu`) targeting the same results folder race against each other and one is silently dropped — so the dataset cannot be flattened into a single results folder reliably.

Emitting `qpx_output/*` lets consumers publish the dataset files flat (e.g. directly into `qpx/` next to `<prefix>.h5mu`) via a `saveAs` that strips the `qpx_output/` prefix.

## Compatibility

- `mudata` and `versions` outputs are unchanged.
- The stub still emits a single `qpx_output/stub.parquet`, so the stub test (`qpx_dataset.size() == 1`) still holds (a glob with multiple matches is emitted as one list).
- `meta.yml` updated to describe the output as files.

Consumed by [bigbio/quantmsdiann](https://github.com/bigbio/quantmsdiann) to flatten QPX export results into a single `qpx/` folder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QPX export process to properly declare and emit individual output files instead of treating the entire output directory as a single unit, enhancing downstream pipeline compatibility and output accuracy.
  * Updated output specification documentation to reflect the refined file-based handling approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->